### PR TITLE
Fix ApiKey detection so it works on Linux

### DIFF
--- a/Apis/Tsw6/Tsw6ApiKey.cs
+++ b/Apis/Tsw6/Tsw6ApiKey.cs
@@ -120,17 +120,17 @@ public class Tsw6ApiKey
     {
         var LinuxNativeKeyLocation = Path.Join(
             Environment.GetFolderPath(
-                    Environment.SpecialFolder.UserProfile),
-                    ".steam",
-                    "steam",
-                    "steamapps",
-                    "compatdata",
-                    tsw6AppId.ToString(),
-                 "pfx",
-                 "drive_c",
-                 "users",
-                 "steamuser",
-                 "Documents",
+                Environment.SpecialFolder.UserProfile),
+                ".steam",
+                "steam",
+                "steamapps",
+                "compatdata",
+                tsw6AppId.ToString(),
+                "pfx",
+                "drive_c",
+                "users",
+                "steamuser",
+                "Documents",
                 commonFileSpec);
         Logger.LogInfo($"Searching for key in:{LinuxNativeKeyLocation}");
         if (File.Exists(LinuxNativeKeyLocation))
@@ -144,21 +144,21 @@ public class Tsw6ApiKey
     {
         var LinuxFlatpakKeyLocation = Path.Join(
             Environment.GetFolderPath(
-                    Environment.SpecialFolder.UserProfile),
-                    ".var",
-                    "app",
-                    "com.valvesoftware.Steam",
-                    ".local",
-                    "share",
-                    "Steam",
-                    "steamapps",
-                    "compatdata",
-                    tsw6AppId.ToString(),
-                    "pfx",
-                    "drive_c",
-                    "users",
-                    "steamuser",
-                    "Documents",
+                Environment.SpecialFolder.UserProfile),
+                ".var",
+                "app",
+                "com.valvesoftware.Steam",
+                ".local",
+                "share",
+                "Steam",
+                "steamapps",
+                "compatdata",
+                tsw6AppId.ToString(),
+                "pfx",
+                "drive_c",
+                "users",
+                "steamuser",
+                "Documents",
                 commonFileSpec);
         Logger.LogInfo($"Searching for key in:{LinuxFlatpakKeyLocation}");
         if (File.Exists(LinuxFlatpakKeyLocation))

--- a/Apis/Tsw6/Tsw6ApiKey.cs
+++ b/Apis/Tsw6/Tsw6ApiKey.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using GameFinder.RegistryUtils;
 using GameFinder.StoreHandlers.Steam;
 using GameFinder.StoreHandlers.Steam.Models.ValueTypes;
+using System.Runtime.InteropServices;
 using NMFS = NexusMods.Paths.FileSystem;
 
 namespace Tsw6RealtimeWeather.Apis.Tsw6;
@@ -37,9 +38,31 @@ public class Tsw6ApiKey
 
     private static string TryToGetApiKeyFromDocuments()
     {
+        var prefix = "";
+        bool isLinux = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+        if (isLinux) {
+           prefix = Path.Join(
+                Environment.GetFolderPath(
+                    Environment.SpecialFolder.UserProfile),
+                    ".steam",
+                    "steam",
+                    "steamapps",
+                    "compatdata",
+                    tsw6AppId.ToString(),
+                 "pfx",
+                 "drive_c",
+                 "users",
+                 "steamuser",
+                 "Documents");
+        }
+        else {
+            prefix = Environment.GetFolderPath(
+            Environment.SpecialFolder.MyDocuments);
+        }
+
         var searchPathForNonDevelopmentMode = Path.Join(
-        Environment.GetFolderPath(
-            Environment.SpecialFolder.MyDocuments),
+            prefix,
             "My Games",
             "TrainSimWorld6",
             "Saved",


### PR DESCRIPTION
The Steam Compatibility Layer creates a virtual C: drive for each installed game. Which means the Tsw6Api Key is in a different location than on Windows and the API cannot find it.

This patch changes the search logic to detect if we are running on Linux and if so change the search location so it finds the Key.